### PR TITLE
Tiled pdf layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - All scenarios use the back-side of the board where the players live in the two bedrooms.
 - For playing it could be useful to print every sheet two times, s.t. each player receives one sheet for his own and can cut the second one in snippets to forward them to the other players after every 5 rounds.
 ## Functionality
-If you want to create new scenarios, you need to pip-install reportlab for generating the pdf output.
+If you want to create new scenarios, you need to pip-install `fpdf` for generating the pdf output, as well as `tqdm` for displaying a progress bar.
 ### Config
 There are multiple parameters you can set within the config:
 - SET_SEED: You can set a seed in the config to your favourite number

--- a/ui/pdf_gen.py
+++ b/ui/pdf_gen.py
@@ -1,51 +1,82 @@
 from typing import List
 
-from reportlab.lib.pagesizes import letter
-from reportlab.pdfgen import canvas
+from fpdf import FPDF
 
 from common.data_classes import ConditionOutput
 from ui.conditions import split_conds_to_4_players
 
 
-def gen_pdf_version(all_conds: List[ConditionOutput], filename: str, game_ident: str, nr_house_combs: int, language: str):
-    c = canvas.Canvas(filename, pagesize=(letter[1], letter[0]))
-    c.setFont("Helvetica", 10)
+def gen_pdf_version(
+    all_conds: List[ConditionOutput],
+    filename: str,
+    game_ident: str,
+    nr_house_combs: int,
+    language: str,
+):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=10)
+
     all_player_conds = split_conds_to_4_players(all_conds)
 
-    info_y = 550
-    first_y = 420
-    second_y = 320
-    third_y = 220
-    fourth_y = 120
+    # Calculate box dimensions
+    page_width = 210
+    page_height = 297
+    margin = 0  # Space around the boxes
+    padding = 7  # Space inside boxes
+    box_width = (page_width - 3 * margin) / 2
+    box_height = (page_height - 3 * margin) / 2
+    y_offset = 10
 
-    row_distance = 20
+    # Write meta information about the game at the top
+    pdf.set_xy(0, 0)
+    pdf.cell(
+        0,
+        10,
+        f"Game_ID: {game_ident}, Nr of possible house combs: {nr_house_combs}",
+        ln=True,
+    )
 
-    left_x = 30
-    right_x = 600
+    # Loop to create 4 boxes, i.e. print information for each player
+    for row in range(2):
+        for col in range(2):
+            x = margin + col * (box_width + margin)
+            y = margin + row * (box_height + margin) + y_offset
 
-    # Scenario info
-    c.drawString(left_x, info_y, f"Game_ID: {game_ident}, Nr of possible house combs: {nr_house_combs}")
-    c.line(left_x, info_y-30, right_x, info_y-30)
+            # Draw box border
+            pdf.rect(x, y, box_width, box_height)
 
-    # Player information
-    players_info = [
-        {"y": first_y, "text": "Player 1"},
-        {"y": second_y, "text": "Player 2"},
-        {"y": third_y, "text": "Player 3"},
-        {"y": fourth_y, "text": "Player 4"}
-    ]
+            # Add title "Player x"
+            player_idx = row * 2 + col + 1
+            player_title = f"Player {player_idx}: {game_ident}"
+            pdf.set_xy(x + padding, y + padding)
+            pdf.cell(0, 10, player_title, ln=True)
 
-    for player_info, player_conds in zip(players_info, all_player_conds):
-        c.drawString(left_x, player_info["y"], f"{player_info['text']}: {game_ident}")
-        for idx, cond in enumerate(player_conds):
-            if language == "ger":
-                text = cond.german_cond
-            elif language == 'eng':
-                text = cond.english_cond
-            else:
-                raise NotImplementedError
-            c.drawString(left_x, player_info["y"] - 25 - idx * row_distance, f"{idx+1}: {text}")
-        c.line(left_x, player_info["y"] - (idx + 1) * row_distance - 20, right_x, player_info["y"] - (idx + 1) * row_distance - 20)
+            # Gather conditions as list
+            player_conds = all_player_conds[player_idx - 1]
+            enumeration = []
+            for i, cond in enumerate(player_conds):
+                if language == "ger":
+                    enumeration.append(f"{cond.german_cond}")
+                elif language == "eng":
+                    enumeration.append(f"{cond.english_cond}")
+                else:
+                    raise NotImplementedError
 
-    c.showPage()
-    c.save()
+            # Add enumeration with long test strings
+            # enumeration = [
+            #     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+            #     "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+            #     "For room livingroom, it applies: If at least 1 object has obj_type = lamp, then there must also be an object with style = retro.",
+            # ]
+
+            # Print each condition as enumeration item
+            initial_x = x + padding
+            pdf.set_xy(initial_x, y + 20)
+            cell_width = box_width - padding * 2  # Adjusted width for wrapping
+            for i, item in enumerate(enumeration, start=1):
+                pdf.multi_cell(cell_width, 7, f"{i}. {item}")
+                # Reset x coordinate for subsequent items to match indentation
+                pdf.set_xy(initial_x, pdf.get_y() + 5)
+
+    pdf.output(filename)

--- a/ui/pdf_gen.py
+++ b/ui/pdf_gen.py
@@ -63,13 +63,6 @@ def gen_pdf_version(
                 else:
                     raise NotImplementedError
 
-            # Add enumeration with long test strings
-            # enumeration = [
-            #     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-            #     "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-            #     "For room livingroom, it applies: If at least 1 object has obj_type = lamp, then there must also be an object with style = retro.",
-            # ]
-
             # Print each condition as enumeration item
             initial_x = x + padding
             pdf.set_xy(initial_x, y + 20)


### PR DESCRIPTION
The generated A4 page is now divided into 4 equally sized tiles plus a small header. This layout makes it easier to cut up the printout. Also, `fpdf` is used instead of `reportlab` since it's a bit easier to use for our use case. The Readme has been updated accordingly.

Some thoughts for additional improvements:
* Use a HTML to PDF converter instead, if enhanced styling shall be added. [This](https://apitemplate.io/blog/how-to-convert-html-to-pdf-using-python/) gives a nice overview. Would require a completely different approach though.
* Generate a second page, on which "playerNum.conditionNum" is printed at exactly the same location as the conditions on the first page. This way, one could print both pages double-sided and have the conditions, that can be given away to the other players, be labeled on the back.